### PR TITLE
Introduce proc macros for scraper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target
 *.bk
 .idea
+.vscode

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,9 +90,9 @@ dependencies = [
 
 [[package]]
 name = "ego-tree"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0a1c26db6cdc3076a84e511b708f85d5c7167a8c65c25fc2279a6315d34777c"
+checksum = "7c6ba7d4eec39eaa9ab24d44a0e73a7949a1095a8b3f3abb11eddf27dbb56a53"
 
 [[package]]
 name = "equivalent"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -435,6 +435,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "scraper_proc_macros"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "scraper",
+ "syn",
+]
+
+[[package]]
 name = "selectors"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,7 @@
 [workspace]
 resolver = "2"
 
-members = ["scraper"]
+members = ["scraper", "scraper_proc_macros"]
+
+[workspace.dependencies]
+scraper = { path = "./scraper" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,4 @@ members = ["scraper", "scraper_proc_macros"]
 
 [workspace.dependencies]
 scraper = { path = "./scraper" }
+scraper_proc_macros = { path = "./scraper_proc_macros" }

--- a/scraper/Cargo.toml
+++ b/scraper/Cargo.toml
@@ -31,6 +31,7 @@ deterministic = ["indexmap"]
 main = ["getopts"]
 atomic = []
 errors = []
+macros = []
 
 [[bin]]
 name = "scraper"

--- a/scraper/Cargo.toml
+++ b/scraper/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 
 [dependencies]
 cssparser = "0.31.0"
-ego-tree = "0.8.0"
+ego-tree = "0.9.0"
 html5ever = "0.27"
 selectors = "0.25.0"
 tendril = "0.4.3"

--- a/scraper/Cargo.toml
+++ b/scraper/Cargo.toml
@@ -31,7 +31,6 @@ deterministic = ["indexmap"]
 main = ["getopts"]
 atomic = []
 errors = []
-macros = []
 
 [[bin]]
 name = "scraper"

--- a/scraper_proc_macros/Cargo.toml
+++ b/scraper_proc_macros/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "scraper_proc_macros"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1.0.86"
+quote = "1.0.37"
+scraper = { workspace = true }
+syn = "2.0.76"

--- a/scraper_proc_macros/src/lib.rs
+++ b/scraper_proc_macros/src/lib.rs
@@ -5,14 +5,17 @@ use syn::{parse_macro_input, LitStr};
 #[proc_macro]
 pub fn selector(input: TokenStream) -> TokenStream {
     let selector = parse_macro_input!(input as LitStr);
-    
+
     match scraper::Selector::parse(&selector.value()) {
         Ok(_) => quote!(
             ::scraper::Selector::parse(#selector).unwrap()
-        ).into(),
+        )
+        .into(),
         Err(e) => syn::Error::new(
             proc_macro2::Span::call_site(),
-            format!("Failed to parse CSS selector: {}", e)
-        ).to_compile_error().into(),
+            format!("Failed to parse CSS selector: {}", e),
+        )
+        .to_compile_error()
+        .into(),
     }
 }

--- a/scraper_proc_macros/src/lib.rs
+++ b/scraper_proc_macros/src/lib.rs
@@ -4,9 +4,9 @@ use syn::{parse_macro_input, LitStr};
 
 #[proc_macro]
 pub fn selector(input: TokenStream) -> TokenStream {
-    let selector = parse_macro_input!(input as LitStr).value();
+    let selector = parse_macro_input!(input as LitStr);
     
-    match scraper::Selector::parse(&selector) {
+    match scraper::Selector::parse(&selector.value()) {
         Ok(_) => quote!(
             ::scraper::Selector::parse(#selector).unwrap()
         ).into(),

--- a/scraper_proc_macros/src/lib.rs
+++ b/scraper_proc_macros/src/lib.rs
@@ -1,0 +1,18 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, LitStr};
+
+#[proc_macro]
+pub fn selector(input: TokenStream) -> TokenStream {
+    let selector = parse_macro_input!(input as LitStr).value();
+    
+    match scraper::Selector::parse(&selector) {
+        Ok(_) => quote!(
+            ::scraper::Selector::parse(#selector).unwrap()
+        ).into(),
+        Err(e) => syn::Error::new(
+            proc_macro2::Span::call_site(),
+            format!("Failed to parse CSS selector: {}", e)
+        ).to_compile_error().into(),
+    }
+}


### PR DESCRIPTION
As of now, the scraper proc macros are an independent crate, and they don't constitute an optional feature, which is what we want to achieve. Moreover the `selector` macro replicates parsing both at runtime and at complie time, because the objects from `selectors` crate don't implement `quote`'s `ToToken` trait, which could allow us to adopt a more efficient approach. For all this reasons, I'll mark this as a draft for now.