### PR TITLE
Fix README symlink

### DIFF
--- a/scraper/README.md
+++ b/scraper/README.md
@@ -1,1 +1,1 @@
-./../README.md
+../README.md


### PR DESCRIPTION
Currently [scraper - crates.io](https://crates.io/crates/scraper) renders readme as:
```text
./../README.md
```