### PR TITLE
Add a serde feature for (de)serializing Selectors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -399,6 +399,7 @@ dependencies = [
  "indexmap",
  "precomputed-hash",
  "selectors",
+ "serde",
  "tendril",
 ]
 

--- a/scraper/Cargo.toml
+++ b/scraper/Cargo.toml
@@ -19,6 +19,7 @@ html5ever = "0.29.0"
 indexmap = { version = "2.7.0", optional = true }
 precomputed-hash = "0.1.1"
 selectors = "0.26.0"
+serde = { version = "1.0.215", optional = true }
 tendril = "0.4.3"
 
 [dependencies.getopts]
@@ -31,6 +32,7 @@ deterministic = ["indexmap"]
 main = ["getopts"]
 atomic = []
 errors = []
+serde = ["dep:serde"]
 
 [[bin]]
 name = "scraper"

--- a/scraper/src/selector.rs
+++ b/scraper/src/selector.rs
@@ -109,7 +109,7 @@ impl<'de> Visitor<'de> for SelectorVisitor {
     }
 
     fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<Self::Value, E> {
-        Ok(Selector::parse(v).map_err(serde::de::Error::custom)?)
+        Selector::parse(v).map_err(serde::de::Error::custom)
     }
 }
 

--- a/scraper/src/selector.rs
+++ b/scraper/src/selector.rs
@@ -101,7 +101,7 @@ impl<'de> Deserialize<'de> for Selector {
 struct SelectorVisitor;
 
 #[cfg(feature = "serde")]
-impl<'de> Visitor<'de> for SelectorVisitor {
+impl Visitor<'_> for SelectorVisitor {
     type Value = Selector;
 
     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {

--- a/scraper/src/selector.rs
+++ b/scraper/src/selector.rs
@@ -11,6 +11,9 @@ use selectors::{
     parser::{self, ParseRelative, SelectorList, SelectorParseErrorKind},
 };
 
+#[cfg(feature = "serde")]
+use serde::{de::Visitor, Deserialize, Serialize};
+
 use crate::error::SelectorErrorKind;
 use crate::ElementRef;
 
@@ -77,6 +80,36 @@ impl ToCss for Selector {
         W: fmt::Write,
     {
         self.selectors.to_css(dest)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl Serialize for Selector {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&self.to_css_string())
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> Deserialize<'de> for Selector {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        deserializer.deserialize_str(SelectorVisitor)
+    }
+}
+
+#[cfg(feature = "serde")]
+struct SelectorVisitor;
+
+#[cfg(feature = "serde")]
+impl<'de> Visitor<'de> for SelectorVisitor {
+    type Value = Selector;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        write!(formatter, "a css selector string")
+    }
+
+    fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<Self::Value, E> {
+        Ok(Selector::parse(v).map_err(serde::de::Error::custom)?)
     }
 }
 


### PR DESCRIPTION
Allow `Selector`s to be  (de)serialized with `serde`.
This will enable devs who rely on `serde` to use this crate without writing their own wrapper type. One of the use cases is storing selectors in config files when building a program with `scraper` as a dependency.

Parsing errors are handled as custom serde errors
```rust
fn visit_str<...>(self, v: &str) -> Result<Self::Value, E> {
    Ok(Selector::parse(v).map_err(serde::de::Error::custom)?)
}
```