### PR TITLE
Bump `selectors` to v0.28

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -354,9 +354,9 @@ dependencies = [
 
 [[package]]
 name = "selectors"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b75e048a93e14929e68e37b82e207db957cbb368375a80ed3ca28ac75080856"
+checksum = "db3079aef7a4383aff1e60eca2818995d3de8168e85ae4b6ea8fb2804b182c54"
 dependencies = [
  "bitflags",
  "cssparser",

--- a/scraper/Cargo.toml
+++ b/scraper/Cargo.toml
@@ -18,7 +18,7 @@ ego-tree = "0.10.0"
 html5ever = "0.31.0"
 indexmap = { version = "2.7.1", optional = true }
 precomputed-hash = "0.1.1"
-selectors = "0.27.0"
+selectors = "0.28.0"
 serde = { version = "1.0.218", optional = true }
 tendril = "0.4.3"
 


### PR DESCRIPTION
I'd also love it if you could get a new release out after this, as I have a large number of duplicate dependency versions in my project.