### PR TITLE
Bump html5ever and selectors dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,15 +4,15 @@ version = 4
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "bitflags"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "byteorder"
@@ -22,9 +22,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "cssparser"
@@ -117,36 +117,35 @@ dependencies = [
 
 [[package]]
 name = "getopts"
-version = "0.2.22"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65f92ffdcc7377b15ba73857be6a1a2fd54aec37baca587b96bc8ea3f8757088"
+checksum = "cba6ae63eb948698e300f645f87c70f76630d505f23b8907cf1e193ee85048c1"
 dependencies = [
  "unicode-width",
 ]
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 
 [[package]]
 name = "html5ever"
-version = "0.31.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953cbbe631aae7fc0a112702ad5d3aaf09da38beaf45ea84610d6e1c358f569c"
+checksum = "55d958c2f74b664487a2035fe1dadb032c48718a03b63f3ab0b8537db8549ed4"
 dependencies = [
  "log",
- "mac",
  "markup5ever",
  "match_token",
 ]
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -160,15 +159,15 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "libc"
-version = "0.2.171"
+version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "lock_api"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -188,23 +187,20 @@ checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
 name = "markup5ever"
-version = "0.16.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ba2225413ed418d540a2c8247d794f4b0527a021da36f69c05344d716dc44c1"
+checksum = "311fe69c934650f8f19652b3946075f0fc41ad8757dbb68f1ca14e7900ecc1c3"
 dependencies = [
  "log",
- "phf",
- "phf_codegen",
- "string_cache",
- "string_cache_codegen",
  "tendril",
+ "web_atoms",
 ]
 
 [[package]]
 name = "match_token"
-version = "0.1.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88a9689d8d44bf9964484516275f5cd4c9b59457a6940c1d5d0ecbb94510a36b"
+checksum = "ac84fd3f360fcc43dc5f5d186f02a94192761a080e8bc58621ad4d12296a58cf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -219,9 +215,9 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -229,9 +225,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
 dependencies = [
  "cfg-if",
  "libc",
@@ -300,9 +296,9 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.94"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
@@ -333,9 +329,9 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.11"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
+checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
 dependencies = [
  "bitflags",
 ]
@@ -363,9 +359,9 @@ dependencies = [
 
 [[package]]
 name = "selectors"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d61a96a0a2d04f964888e003ec83e3172159a16e81b35de9f6ab85d8767cf2b1"
+checksum = "3df44ba8a7ca7a4d28c589e04f526266ed76b6cc556e33fe69fa25de31939a65"
 dependencies = [
  "bitflags",
  "cssparser",
@@ -402,9 +398,9 @@ dependencies = [
 
 [[package]]
 name = "servo_arc"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae65c4249478a2647db249fb43e23cec56a2c8974a427e7bd8cb5a1d0964921a"
+checksum = "204ea332803bd95a0b60388590d59cf6468ec9becf626e2451f1d26a1d972de4"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -417,9 +413,9 @@ checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "smallvec"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "stable_deref_trait"
@@ -454,9 +450,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.100"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -482,15 +478,27 @@ checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.14"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
 
 [[package]]
 name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "web_atoms"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57ffde1dc01240bdf9992e3205668b235e59421fd085e8a317ed98da0178d414"
+dependencies = [
+ "phf",
+ "phf_codegen",
+ "string_cache",
+ "string_cache_codegen",
+]
 
 [[package]]
 name = "windows-targets"

--- a/scraper/Cargo.toml
+++ b/scraper/Cargo.toml
@@ -15,10 +15,10 @@ readme = "README.md"
 [dependencies]
 cssparser = "0.35.0"
 ego-tree = "0.10.0"
-html5ever = "0.31.0"
+html5ever = "0.35.0"
 indexmap = { version = "2.7.1", optional = true }
 precomputed-hash = "0.1.1"
-selectors = "0.29.0"
+selectors = "0.30.0"
 serde = { version = "1.0.218", optional = true }
 tendril = "0.4.3"
 

--- a/scraper/examples/document.rs
+++ b/scraper/examples/document.rs
@@ -20,7 +20,7 @@ fn main() {
     stdin.read_to_string(&mut input).unwrap();
     let document = Html::parse_document(&input);
 
-    println!("{:#?}", document);
+    println!("{document:#?}");
 
     for node in document.select(&selector) {
         println!("{:?}", node.value());

--- a/scraper/examples/fragment.rs
+++ b/scraper/examples/fragment.rs
@@ -20,7 +20,7 @@ fn main() {
     stdin.read_to_string(&mut input).unwrap();
     let fragment = Html::parse_fragment(&input);
 
-    println!("{:#?}", fragment);
+    println!("{fragment:#?}");
 
     for node in fragment.select(&selector) {
         println!("{:?}", node.value());

--- a/scraper/src/error.rs
+++ b/scraper/src/error.rs
@@ -83,7 +83,7 @@ impl Display for SelectorErrorKind<'_> {
                     format!("Token {:?} was not expected", utils::render_token(token))
                 }
                 Self::EndOfLine => "Unexpected EOL".to_string(),
-                Self::InvalidAtRule(rule) => format!("Invalid @-rule {:?}", rule),
+                Self::InvalidAtRule(rule) => format!("Invalid @-rule {rule:?}"),
                 Self::InvalidAtRuleBody => "The body of an @-rule was invalid".to_string(),
                 Self::QualRuleInvalid => "The qualified name was invalid".to_string(),
                 Self::ExpectedColonOnPseudoElement(token) => format!(
@@ -95,8 +95,7 @@ impl Display for SelectorErrorKind<'_> {
                     utils::render_token(token)
                 ),
                 Self::UnexpectedSelectorParseError(err) => format!(
-                    "Unexpected error occurred. Please report this to the developer\n{:#?}",
-                    err
+                    "Unexpected error occurred. Please report this to the developer\n{err:#?}"
                 ),
             }
         )

--- a/scraper/src/error/utils.rs
+++ b/scraper/src/error/utils.rs
@@ -3,9 +3,9 @@ use cssparser::Token;
 pub(crate) fn render_token(token: &Token<'_>) -> String {
     match token {
         Token::Ident(ident) => ident.to_string(),
-        Token::AtKeyword(value) => format!("@{}", value),
-        Token::Hash(name) | Token::IDHash(name) => format!("#{}", name),
-        Token::QuotedString(value) => format!("\"{}\"", value),
+        Token::AtKeyword(value) => format!("@{value}"),
+        Token::Hash(name) | Token::IDHash(name) => format!("#{name}"),
+        Token::QuotedString(value) => format!("\"{value}\""),
         Token::UnquotedUrl(value) => value.to_string(),
         Token::Number {
             has_sign: signed,
@@ -24,10 +24,10 @@ pub(crate) fn render_token(token: &Token<'_>) -> String {
             unit,
         } => format!("{}{}", render_int(*signed, *num), unit),
         Token::WhiteSpace(_) => String::from(" "),
-        Token::Comment(comment) => format!("/* {} */", comment),
-        Token::Function(name) => format!("{}()", name),
-        Token::BadString(string) => format!("<Bad String {:?}>", string),
-        Token::BadUrl(url) => format!("<Bad URL {:?}>", url),
+        Token::Comment(comment) => format!("/* {comment} */"),
+        Token::Function(name) => format!("{name}()"),
+        Token::BadString(string) => format!("<Bad String {string:?}>"),
+        Token::BadUrl(url) => format!("<Bad URL {url:?}>"),
         // Single-character token
         Token::Colon => ":".into(),
         Token::Semicolon => ";".into(),
@@ -54,7 +54,7 @@ fn render_number(signed: bool, num: f32, token: &Token) -> String {
 
     match token {
         Token::Number { .. } => num,
-        Token::Percentage { .. } => format!("{}%", num),
+        Token::Percentage { .. } => format!("{num}%"),
         _ => panic!("render_number is not supposed to be called on a non-numerical token"),
     }
 }
@@ -69,14 +69,14 @@ fn render_int(signed: bool, num: f32) -> String {
 
 fn render_int_signed(num: f32) -> String {
     if num > 0.0 {
-        format!("+{}", num)
+        format!("+{num}")
     } else {
-        format!("-{}", num)
+        format!("-{num}")
     }
 }
 
 fn render_int_unsigned(num: f32) -> String {
-    format!("{}", num)
+    format!("{num}")
 }
 
 #[cfg(test)]

--- a/scraper/src/html/mod.rs
+++ b/scraper/src/html/mod.rs
@@ -104,7 +104,7 @@ impl Html {
     }
 
     /// Returns the root `<html>` element.
-    pub fn root_element(&self) -> ElementRef {
+    pub fn root_element(&self) -> ElementRef<'_> {
         let root_node = self
             .tree
             .root()

--- a/scraper/src/html/mod.rs
+++ b/scraper/src/html/mod.rs
@@ -89,6 +89,7 @@ impl Html {
             Default::default(),
             QualName::new(None, ns!(html), local_name!("body")),
             Vec::new(),
+            false,
         );
         parser.one(fragment)
     }

--- a/scraper/src/node.rs
+++ b/scraper/src/node.rs
@@ -114,11 +114,11 @@ impl fmt::Debug for Node {
         match *self {
             Node::Document => write!(f, "Document"),
             Node::Fragment => write!(f, "Fragment"),
-            Node::Doctype(ref d) => write!(f, "Doctype({:?})", d),
-            Node::Comment(ref c) => write!(f, "Comment({:?})", c),
-            Node::Text(ref t) => write!(f, "Text({:?})", t),
-            Node::Element(ref e) => write!(f, "Element({:?})", e),
-            Node::ProcessingInstruction(ref pi) => write!(f, "ProcessingInstruction({:?})", pi),
+            Node::Doctype(ref d) => write!(f, "Doctype({d:?})"),
+            Node::Comment(ref c) => write!(f, "Comment({c:?})"),
+            Node::Text(ref t) => write!(f, "Text({t:?})"),
+            Node::Element(ref e) => write!(f, "Element({e:?})"),
+            Node::ProcessingInstruction(ref pi) => write!(f, "ProcessingInstruction({pi:?})"),
         }
     }
 }
@@ -275,7 +275,7 @@ impl Element {
     }
 
     /// Returns an iterator over the element's classes.
-    pub fn classes(&self) -> Classes {
+    pub fn classes(&self) -> Classes<'_> {
         let classes = self.classes.get_or_init(|| {
             let mut classes = self
                 .attrs
@@ -313,7 +313,7 @@ impl Element {
     }
 
     /// Returns an iterator over the element's attributes.
-    pub fn attrs(&self) -> Attrs {
+    pub fn attrs(&self) -> Attrs<'_> {
         Attrs {
             inner: self.attrs.iter(),
         }
@@ -362,7 +362,7 @@ impl fmt::Debug for Element {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         write!(f, "<{}", self.name())?;
         for (key, value) in self.attrs() {
-            write!(f, " {}={:?}", key, value)?;
+            write!(f, " {key}={value:?}")?;
         }
         write!(f, ">")
     }

--- a/scraper/src/selector.rs
+++ b/scraper/src/selector.rs
@@ -28,7 +28,7 @@ pub struct Selector {
 
 impl Selector {
     /// Parses a CSS selector group.
-    pub fn parse(selectors: &'_ str) -> Result<Self, SelectorErrorKind> {
+    pub fn parse(selectors: &str) -> Result<Self, SelectorErrorKind<'_>> {
         let mut parser_input = cssparser::ParserInput::new(selectors);
         let mut parser = cssparser::Parser::new(&mut parser_input);
 


### PR DESCRIPTION
Also do ‘cargo update’ to update the lock file.  Testet with `cargo test && cargo test --no-default-featurs && cargo test --all-features`.