### PR TITLE
Document the relationship between the core node and element types

### DIFF
--- a/scraper/src/lib.rs
+++ b/scraper/src/lib.rs
@@ -13,36 +13,40 @@
 
 //! # The core types
 //!
-//! Parsing an input produces an [`Html`] document that owns a tree of
+//! Parsing produces an [`Html`] document that owns a tree of
 //! [`Node`]s. Every node is one variant of the [`Node`] enum, for example
 //! [`Node::Text`] for text and [`Node::Element`] for an element. The data that
-//! belongs to an element node, its name and its attributes, is held in a
+//! belongs to an element node, like its attributes, is held in a
 //! [`node::Element`](crate::node::Element).
 //!
 //! Running a [`Selector`] over a document does not hand back bare [`Node`]s.
-//! It yields [`ElementRef`]s, each one a handle to an element node that also
-//! knows where it sits in the tree. From an [`ElementRef`] you can reach the
-//! element data with [`ElementRef::value`], read the text under it with
-//! [`ElementRef::text`], or select further into its descendants. Because an
-//! [`ElementRef`] also dereferences to an `ego_tree::NodeRef`, the tree
-//! navigation methods (parent, children, siblings) are available on it too.
+//! CSS selectors only ever match elements, so it yields [`ElementRef`]s, each
+//! one a handle to an element node that also knows where it sits in the tree.
+//! From an [`ElementRef`] you can reach the element data with
+//! [`ElementRef::value`], read the text under it with [`ElementRef::text`], or
+//! select further into its descendants. Because an [`ElementRef`] also
+//! dereferences to an `ego_tree::NodeRef`, the tree navigation methods (parent,
+//! children, siblings) are available on it too.
 //!
 //! The re-exported [`Element`] trait is a different thing from
 //! [`node::Element`](crate::node::Element). The trait comes from the
 //! `selectors` crate and is what lets an [`ElementRef`] be matched against a
-//! CSS selector. Most code never needs to name it directly.
+//! CSS selector. Most code never names it directly, though its convenience
+//! methods (such as `parent_element`) are available on an [`ElementRef`]
+//! through the trait impl, which is why it is re-exported.
 //!
 //! ```
 //! use scraper::{Html, Selector};
 //!
-//! let document = Html::parse_fragment(r#"<ul><li id="a">one</li><li>two</li></ul>"#);
+//! let document = Html::parse_fragment(r#"<ul><li id="a">one</li><li>two <em>three</em></li></ul>"#);
 //! let selector = Selector::parse("li").unwrap();
 //!
 //! for element in document.select(&selector) {
 //!     // The element data: its tag name and attributes.
 //!     let name = element.value().name();
-//!     let id = element.value().id();
-//!     // The text nodes below this element, concatenated.
+//!     // `attr` is the short-hand for reading a single attribute by name.
+//!     let id = element.attr("id");
+//!     // All descendant text nodes below this element, concatenated.
 //!     let text = element.text().collect::<String>();
 //!     println!("{name} id={id:?} text={text:?}");
 //! }

--- a/scraper/src/lib.rs
+++ b/scraper/src/lib.rs
@@ -11,6 +11,43 @@
     variant_size_differences
 )]
 
+//! # The core types
+//!
+//! Parsing an input produces an [`Html`] document that owns a tree of
+//! [`Node`]s. Every node is one variant of the [`Node`] enum, for example
+//! [`Node::Text`] for text and [`Node::Element`] for an element. The data that
+//! belongs to an element node, its name and its attributes, is held in a
+//! [`node::Element`](crate::node::Element).
+//!
+//! Running a [`Selector`] over a document does not hand back bare [`Node`]s.
+//! It yields [`ElementRef`]s, each one a handle to an element node that also
+//! knows where it sits in the tree. From an [`ElementRef`] you can reach the
+//! element data with [`ElementRef::value`], read the text under it with
+//! [`ElementRef::text`], or select further into its descendants. Because an
+//! [`ElementRef`] also dereferences to an `ego_tree::NodeRef`, the tree
+//! navigation methods (parent, children, siblings) are available on it too.
+//!
+//! The re-exported [`Element`] trait is a different thing from
+//! [`node::Element`](crate::node::Element). The trait comes from the
+//! `selectors` crate and is what lets an [`ElementRef`] be matched against a
+//! CSS selector. Most code never needs to name it directly.
+//!
+//! ```
+//! use scraper::{Html, Selector};
+//!
+//! let document = Html::parse_fragment(r#"<ul><li id="a">one</li><li>two</li></ul>"#);
+//! let selector = Selector::parse("li").unwrap();
+//!
+//! for element in document.select(&selector) {
+//!     // The element data: its tag name and attributes.
+//!     let name = element.value().name();
+//!     let id = element.value().id();
+//!     // The text nodes below this element, concatenated.
+//!     let text = element.text().collect::<String>();
+//!     println!("{name} id={id:?} text={text:?}");
+//! }
+//! ```
+
 #[macro_use]
 extern crate html5ever;
 

--- a/scraper/src/node.rs
+++ b/scraper/src/node.rs
@@ -217,12 +217,12 @@ pub type Attributes = indexmap::IndexMap<QualName, StrTendril>;
 #[cfg(not(feature = "deterministic"))]
 pub type Attributes = Vec<(QualName, StrTendril)>;
 
-/// The name and attributes of an HTML element.
+/// An HTML element.
 ///
 /// This is the data stored in a [`Node::Element`] node. It is distinct from the
 /// [`Element`](selectors::Element) trait re-exported at the crate root, which is
 /// implemented by [`ElementRef`](crate::ElementRef) for CSS selector matching.
-/// To get one from a selected element, call
+/// To access the underlying element of a selected element, call
 /// [`ElementRef::value`](crate::ElementRef::value).
 #[derive(Clone, PartialEq, Eq)]
 pub struct Element {

--- a/scraper/src/node.rs
+++ b/scraper/src/node.rs
@@ -217,7 +217,13 @@ pub type Attributes = indexmap::IndexMap<QualName, StrTendril>;
 #[cfg(not(feature = "deterministic"))]
 pub type Attributes = Vec<(QualName, StrTendril)>;
 
-/// An HTML element.
+/// The name and attributes of an HTML element.
+///
+/// This is the data stored in a [`Node::Element`] node. It is distinct from the
+/// [`Element`](selectors::Element) trait re-exported at the crate root, which is
+/// implemented by [`ElementRef`](crate::ElementRef) for CSS selector matching.
+/// To get one from a selected element, call
+/// [`ElementRef::value`](crate::ElementRef::value).
 #[derive(Clone, PartialEq, Eq)]
 pub struct Element {
     /// The element name.


### PR DESCRIPTION
Closes #210. Adds a short overview in the crate docs explaining how Html, Node, node::Element, ElementRef and the re-exported Element trait relate and how you move between them, with a runnable example, and clarifies the node::Element doc so it is not confused with the selectors Element trait.